### PR TITLE
Seriously circling in on perfect register mode control and persistence; a few goodies

### DIFF
--- a/autoload/buffest.vim
+++ b/autoload/buffest.vim
@@ -51,7 +51,8 @@ endf
 " Gets called when a buffer name globbed '@*' is encountered.
 " Path gets matched against tmpfile generation method, so should work without
 " exta maintenance. glob pattern (in autocomd) could be centralized still.
-function! buffest#adapt_buffer() abort
+function! buffest#adapt_buffer(...) abort
+    let overrideReg = get(a:, 1, 0)
     let filename = expand('%:p')
     let matchingReg = ''
     for reg in g:buffest_supported_registers
@@ -63,6 +64,11 @@ function! buffest#adapt_buffer() abort
         let l:regname = tolower(matchingReg)
         if index(g:buffest_supported_registers, l:regname) < 0
           throw g:buffest_unsupported_register_error
+        endif
+        if overrideReg
+            set nofixeol noeol
+            w!
+            call buffest#Set_list2reg(matchingReg, buffest#Readfile(expand('%:p')))
         endif
         call buffest#regdo(matchingReg, 'edit')
     endif

--- a/autoload/buffest.vim
+++ b/autoload/buffest.vim
@@ -110,7 +110,7 @@ function! buffest#regdo(regname, cmd)
   endif
   exec a:cmd . ' ' . buffest#tmpname('@'.l:regname)
   set filetype=buffestreg
-  let b:buffest_regname = a:reg
+  let b:buffest_regname = a:regname
 
   edit!
 endfunction

--- a/autoload/buffest.vim
+++ b/autoload/buffest.vim
@@ -4,6 +4,71 @@ let g:buffest_unsupported_register_error = 'buffest: E1: register not supported'
 
 let g:buffest_supported_list_fields = ['filename', 'module', 'lnum', 'pattern', 'col', 'vcol', 'nr', 'text', 'type', 'valid']
 
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+"  working around vim's register modes and write modes  "
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+fun! buffest#RegFileIntoBuffer(file, modeAtWriting) abort
+    exec "edit! ".a:file
+    set nofixeol noeol
+    if a:modeAtWriting ==# 'V'
+        normal Go
+    endif
+endf
+fun! buffest#RegModeFromList(list) abort
+    if empty(a:list) || !empty(a:list[-1])
+        return 'v'
+    endif
+    return 'V'
+endf
+fun! buffest#Get_reg2list(regname) abort
+    let processed = getreg('+', 1, 1) + (getregtype('+') ==# "V" ? [''] : [] )
+    return processed
+endf
+fun! buffest#Set_list2reg(regname, list) abort
+    let mode = buffest#RegModeFromList(a:list)
+    if mode ==# 'V'
+        " we have of course to strip that indicating newline again
+        let internalRepr = a:list[0:-2]
+    else
+        let internalRepr = a:list
+    endif
+    " echom 'the mode is: '.mode
+    call setreg(a:regname, internalRepr, mode)
+    return getreg(a:regname)
+endf
+fun! buffest#Readfile(file) abort
+    return readfile(a:file, 'b')
+endf
+fun! buffest#Writefile(content, file) abort
+    call writefile(a:content, a:file, 'b')
+    return buffest#RegModeFromList(a:content)
+endf
+
+""""""""""""""""""""""""""""""""""""""""""""
+"  end of working around vim corner cases  "
+""""""""""""""""""""""""""""""""""""""""""""
+
+" Gets called when a buffer name globbed '@*' is encountered.
+" Path gets matched against tmpfile generation method, so should work without
+" exta maintenance. glob pattern (in autocomd) could be centralized still.
+function! buffest#adapt_buffer() abort
+    let filename = expand('%:p')
+    let matchingReg = ''
+    for reg in g:buffest_supported_registers
+        if buffest#tmpname('@'.reg) ==# filename
+            let matchingReg = reg
+        endif
+    endfor
+    if !empty(matchingReg)
+        let l:regname = tolower(matchingReg)
+        if index(g:buffest_supported_registers, l:regname) < 0
+          throw g:buffest_unsupported_register_error
+        endif
+        call buffest#regdo(matchingReg, 'edit')
+    endif
+endf
+
 function! buffest#tmpname(name)
   let l:tmp = '/'.$TMP.'/buffest/'
   if $TMP == ""
@@ -18,16 +83,20 @@ function! buffest#readreg()
     return
   endif
   let l:regname = tolower(b:buffest_regname)
-  call writefile(getreg(l:regname, 1, 1), expand('%:p'))
-  edit!
+
+let writecontent = buffest#Get_reg2list(l:regname)
+let file = expand('%:p')
+let modeAtWriting = buffest#Writefile(writecontent, file)
+call buffest#RegFileIntoBuffer(file, modeAtWriting)
 endfunction
+
 
 function! buffest#writereg()
   if !exists('b:buffest_regname')
     return
   endif
   let l:regname = tolower(b:buffest_regname)
-  call setreg(l:regname, readfile(expand('%')))
+  call buffest#Set_list2reg(l:regname, buffest#Readfile(expand('%:p')))
 endfunction
 
 function! buffest#regcomplete(...)
@@ -40,8 +109,9 @@ function! buffest#regdo(regname, cmd)
     throw g:buffest_unsupported_register_error
   endif
   exec a:cmd . ' ' . buffest#tmpname('@'.l:regname)
-  let b:buffest_regname = l:regname
   set filetype=buffestreg
+  let b:buffest_regname = a:reg
+
   edit!
 endfunction
 
@@ -98,7 +168,7 @@ function! buffest#readloclist()
   return buffest#readlist(getloclist('.'))
 endfunction
 
-function buffest#writelistfile()
+function! buffest#writelistfile()
   let contents = []
   for line in readfile(expand('%'))
     execute 'let contents += ['.buffest#unescseparator(line).']'
@@ -106,23 +176,23 @@ function buffest#writelistfile()
   return contents
 endfunction
 
-function buffest#writeqflist()
+function! buffest#writeqflist()
   call setqflist(buffest#writelistfile())
 endfunction
 
-function buffest#writeloclist()
+function! buffest#writeloclist()
   call setloclist('.', buffest#writelistfile())
 endfunction
 
-function buffest#listfieldcomplete(...)
+function! buffest#listfieldcomplete(...)
   return g:buffest_supported_list_fields
 endfunction
 
-function buffest#filterlistfields(list)
+function! buffest#filterlistfields(list)
   return filter(uniq([] + a:list), 'index(g:buffest_supported_list_fields, v:val) >= 0')
 endfunction
 
-function buffest#qflistdo(cmd, ...)
+function! buffest#qflistdo(cmd, ...)
   exec a:cmd . ' ' . buffest#tmpname(',q')
   " must create a new array for uniq to work
   let b:buffest_list_fields = buffest#filterlistfields(a:000)
@@ -130,7 +200,7 @@ function buffest#qflistdo(cmd, ...)
   edit!
 endfunction
 
-function buffest#loclistdo(cmd, ...)
+function! buffest#loclistdo(cmd, ...)
   exec a:cmd . ' ' . buffest#tmpname(',l')
   " must create a new array for uniq to work
   let b:buffest_list_fields = buffest#filterlistfields(a:000)

--- a/autoload/buffest.vim
+++ b/autoload/buffest.vim
@@ -33,7 +33,6 @@ fun! buffest#Set_list2reg(regname, list) abort
     else
         let internalRepr = a:list
     endif
-    " echom 'the mode is: '.mode
     call setreg(a:regname, internalRepr, mode)
     return getreg(a:regname)
 endf
@@ -83,10 +82,8 @@ function! buffest#readreg()
     return
   endif
   let l:regname = tolower(b:buffest_regname)
-  echom '!!' . l:regname
 
 let writecontent = buffest#Get_reg2list(l:regname)
-echom '!!writecontent '. string(writecontent)
 let file = expand('%:p')
 let modeAtWriting = buffest#Writefile(writecontent, file)
 call buffest#RegFileIntoBuffer(file, modeAtWriting)

--- a/autoload/buffest.vim
+++ b/autoload/buffest.vim
@@ -22,7 +22,7 @@ fun! buffest#RegModeFromList(list) abort
     return 'V'
 endf
 fun! buffest#Get_reg2list(regname) abort
-    let processed = getreg('+', 1, 1) + (getregtype('+') ==# "V" ? [''] : [] )
+    let processed = getreg(a:regname, 1, 1) + (getregtype(a:regname) ==# "V" ? [''] : [] )
     return processed
 endf
 fun! buffest#Set_list2reg(regname, list) abort
@@ -83,8 +83,10 @@ function! buffest#readreg()
     return
   endif
   let l:regname = tolower(b:buffest_regname)
+  echom '!!' . l:regname
 
 let writecontent = buffest#Get_reg2list(l:regname)
+echom '!!writecontent '. string(writecontent)
 let file = expand('%:p')
 let modeAtWriting = buffest#Writefile(writecontent, file)
 call buffest#RegFileIntoBuffer(file, modeAtWriting)
@@ -110,8 +112,7 @@ function! buffest#regdo(regname, cmd)
   endif
   exec a:cmd . ' ' . buffest#tmpname('@'.l:regname)
   set filetype=buffestreg
-  let b:buffest_regname = a:regname
-
+  let b:buffest_regname = l:regname
   edit!
 endfunction
 

--- a/ftplugin/buffestreg.vim
+++ b/ftplugin/buffestreg.vim
@@ -2,6 +2,7 @@ augroup buffestreg
   autocmd!
   autocmd BufWritePost <buffer> call buffest#writereg()
   autocmd BufEnter <buffer> call buffest#readreg()
+  autocmd BufNewFile,BufRead @* call buffest#adapt_buffer()
 augroup END
 
 setlocal bufhidden=delete

--- a/plugin/buffest.vim
+++ b/plugin/buffest.vim
@@ -1,6 +1,8 @@
 " Commands {{{
 
 command! -complete=customlist,buffest#regcomplete -nargs=1
+      \ Regedit call buffest#regdo(<f-args>, 'edit')
+command! -complete=customlist,buffest#regcomplete -nargs=1
       \ Regsplit call buffest#regdo(<f-args>, 'split')
 command! -complete=customlist,buffest#regcomplete -nargs=1
       \ Regvsplit call buffest#regdo(<f-args>, 'vsplit')

--- a/plugin/buffest.vim
+++ b/plugin/buffest.vim
@@ -9,6 +9,11 @@ command! -complete=customlist,buffest#regcomplete -nargs=1
 command! -complete=customlist,buffest#regcomplete -nargs=1
       \ Regtabedit call buffest#regdo(<f-args>, 'tabedit')
 
+command! -complete=customlist,buffest#regcomplete -nargs=1 Regwrite 
+      \ exec 'silent! bw! '.buffest#tmpname('@'.<q-args>) | 
+      \ exec 'saveas! '.buffest#tmpname('@'.<q-args>) | 
+      \ call buffest#adapt_buffer(1)
+
 command! -complete=customlist,buffest#listfieldcomplete -nargs=*
       \ Qflistsplit call buffest#qflistdo('split', <f-args>)
 command! -complete=customlist,buffest#listfieldcomplete -nargs=*


### PR DESCRIPTION
This PR fixes the following problems:
When loading a character-wise register into a Regsplit window, on writing it, the register will have a newline at its end - producing surprising behavior when pasting it again (before: fit snugly into the same line -- now, produces linebreak, you gotta join lines, aaaah~~) 

This is once more result of vim's tendency for corner cases, mixing flag behavior and so on. My efforts concentrated on achieving 1) transparency between files and in-memory registers w.r.t their set mode wrt. character- and line mode. block selection mode is not supported. 2) minimization of corner case behavior if any, 3) transparency to the user w.r.t. which sort of register mode (line, character) they will achieve with the `:w`riting of an register.

The following behaviour is established:
- The endline at the end of a register buffer or its absence signalized whether it is supposed to be line-wise (with \n) or a characterwise (without \n i.e. without empty last line).
- Register buffers are initialized using the flags 'noendofline' and 'nofixendofline' to guarantee that VIM won't stealth-insert newline characters. Also, these flags are needed because the user would not be able to see their decisive trailing newline if it were implicit (as is default, see 'eol' option and that whole rest of the rabbit hole). Unfortunately, a little `normal Go<Esc>` was needed to initialize a Regsplit buffer in case of a linewise register, but nothing more.
- intermediate representation is a list of lines, adequatly, with an empty list item at the end or not, see code
- Only corner case: with an empty Regsplit buffer (no register content at all) the User is forced to have that as character-wise register. This was the most minimal corner case I could find wothout having multimodal persistence. I am convinced no-one would miss to be able to have an empty linewise register producible through this plug-in, especially since the behavior before was much more unpredictable.


----
Extra goodies, take them or throw them away, I think they are useful:
 - On re-encountering a reg-split buffer, e.g. via `<C-o><C-o><C-i>`, the nature of the buffer (buflocal variable, filetype) is now preserved through `BufNewFile`, `BufRead` autocommands. Completely side-effect free w.r.t. intended prev. behavior. uses as entry point the `buffest#regdo` method to guarantee  near-zero increased maintenance.
 - Extra Command: `Regedit`, Same as `Reg(v)split`, but stays in the current window. Fots my workflow of splitting first with `vs`/`sp`, then using commands, I'm sure it could be usedful. Has to be documented still if taken over.

I hope you excuse me not opening an issue first nor searching for a contribution guideline first. Let me know if you see issues!
