### PR TITLE
Fix inconsistent handling of trailing newlines

### DIFF
--- a/autoload/buffest.vim
+++ b/autoload/buffest.vim
@@ -115,7 +115,11 @@ function! buffest#read_reg() abort
   if l:regname == v:null
     return
   endif
-  call writefile(getreg(l:regname, 1, 1), l:filename)
+  let l:reg = getreg(l:regname, 1, 1)
+  if getreg(l:regname, 1)[-1:] ==# "\n"
+    let l:reg += ['']
+  endif
+  call writefile(l:reg, l:filename)
   edit!
 endfunction
 
@@ -125,7 +129,7 @@ function! buffest#write_reg() abort
   if l:regname == v:null
     return
   endif
-  call setreg(l:regname, readfile(l:filename), visualmode())
+  call setreg(l:regname, join(readfile(l:filename), "\n"), visualmode())
 endfunction
 
 " }}}


### PR DESCRIPTION
I've been having issues with vim-buffest when trying to edit macro registers - buffest was inserting an extra `\n` at the end of the register, even though the original register ended without a newline.

This stems from a few of vim's behaviors:
1. the `getreg(<reg>, 1, 1)` and `readfile()` functions both return lists, one element per line; whether or not the register/file ended with a trailing newline, you will get the same resultant list
2.  when passed lists, `setreg()` and `writefile()` implicitly add a newline to the end of each list item, including the last item
3. when editing editing a file that does **not** end in a newline, vim always adds a trailing newline when writing the file

As a result of the first point, it's impossible to know just based on the list whether the register/file ended in a trailing newline. 

As a result of the second point, a trailing newline will always be added to a register set with `setreg()` or a file written with `writefile()` **if** those functions are passed lists (`writefile()` requires a list, but `setreg()` will accept a string or a list). 

A naive workaround is to basically ignore one of the trailing newlines in the `buffest#write_reg()` function. This can be accomplished by joining the list returned by `readfile()` on `\n`:

```diff
-  call setreg(l:regname, readfile(l:filename), visualmode())
+  call setreg(l:regname, join(readfile(l:filename), "\n"), visualmode())
```

This will fix cases where the original register did not end in a newline, but if it ended in 1+ newlines you will lose a newline.

To work around this, it's necessary to test the raw register string inside of `buffest#read_reg` to see if it ends in a trailing newline. We can call `getreg()` without the third argument to get a string rather than a list. If the string ends in a newline, we should add an **extra** newline before writing the temporary file:

  ```diff
-  call writefile(getreg(l:regname, 1, 1), l:filename)
+  let l:reg = getreg(l:regname, 1, 1)
+  if getreg(l:regname, 1)[-1:] ==# "\n"
+    let l:reg += ['']
+  endif
+  call writefile(l:reg, l:filename)
```

The net result is that the temporary file written by `buffest#read_reg` will always have `n+1` newlines, so we know that we can always remove one newline inside of `buffest#write_reg` to get back to the original number of newlines.

Sorry for the long explanation, the bug is a bit nuanced so I wanted to explain exactly what was going on.